### PR TITLE
docs(r): update R documentation to match current API

### DIFF
--- a/docs/Use Kgen/r.md
+++ b/docs/Use Kgen/r.md
@@ -20,7 +20,10 @@ Kgen is available for installation from CRAN:
 or directly from Github using remotes/devtools:
 `devtools::install_github('PalaeoCarb/Kgen/r')`
 
-This will install Kgen and its dependencies. Kgen relies on `pymyami` for [Mg] and [Ca] correction factors when using the `MyAMI` or `MyAMI_Polynomial` methods. The required version of `pymyami` is automatically resolved via [reticulate](https://rstudio.github.io/reticulate/) when the package is loaded.
+This will install Kgen and its dependencies. Kgen relies on `pymyami` for [Mg] and [Ca] correction factors when using the `MyAMI` or `MyAMI_Polynomial` methods. The required version of `pymyami` is automatically resolved via [reticulate](https://rstudio.github.io/reticulate/) on first use.
+
+For parallel execution support, install the optional packages:
+`install.packages(c("future", "future.apply", "progressr"))`
 
 ## Getting Started
 
@@ -73,13 +76,15 @@ The inputs to **temp_c**, **p_bar**, **sal**, **magnesium**, **calcium**, **sulp
 
 ## Parallel Execution
 
-`calc_Ks()` uses the [future](https://future.futureverse.org/) framework for parallel computation. To enable parallel execution, set a `future::plan()` before calling `calc_Ks()`:
+`calc_Ks()` supports parallel computation via the [future](https://future.futureverse.org/) framework. The `future`, `future.apply`, and `progressr` packages are optional — when not installed, `calc_Ks()` falls back to sequential execution automatically.
+
+To enable parallel execution, set a `future::plan()` before calling `calc_Ks()`:
 
 ```R
 library('kgen')
 
 # Enable parallel execution
-future::plan(future::multisession, workers = parallel::detectCores() - 1)
+future::plan(future::multisession, workers = future::availableCores() - 1)
 
 # Calculate Ks in parallel
 result <- calc_Ks(temp_c = 25, sal = 35)
@@ -88,7 +93,7 @@ result <- calc_Ks(temp_c = 25, sal = 35)
 future::plan(future::sequential)
 ```
 
-## Details
+## Example
 
 Kgen installation and operation example:
 

--- a/docs/Use Kgen/r.md
+++ b/docs/Use Kgen/r.md
@@ -17,26 +17,41 @@ Documentation to start using Kgen in R.
 
 Kgen is available for installation from CRAN:
 `install.packages('kgen')`
-or directly from Github using remotes/devtools: 
+or directly from Github using remotes/devtools:
 `devtools::install_github('PalaeoCarb/Kgen/r')`
 
-This will install Kgen and its dependencies.
+This will install Kgen and its dependencies. Kgen relies on `pymyami` for [Mg] and [Ca] correction factors when using the `MyAMI` or `MyAMI_Polynomial` methods. The required version of `pymyami` is automatically resolved via [reticulate](https://rstudio.github.io/reticulate/) when the package is loaded.
 
 ## Getting Started
 
-Two functions are exported, `calc_Ks()` for returning all available Ks, and `calc_pressure_correction()` for returning a K-specific pressure correction factor. To allow for the best possible cross-compatibility between languages, Kgen for R relies on `pymyami` to calculate [Mg] and [Ca] correction factors. Upon first use, Kgen will ask to automatically install a local version of `r-Miniconda` along with `pymyami`. This step should not require more than 5 minutes on modern systems. If you prefer to install r-Miniconda to a specific path on your system, stop the installer and install r-Miniconda manually using [reticulate](https://rstudio.github.io/reticulate/). 
+Four functions are exported:
+
+- `calc_K()` for returning a single K at given conditions
+- `calc_Ks()` for returning all available Ks
+- `calc_pressure_correction()` for returning a K-specific pressure correction factor
+- `calc_seawater_correction()` for returning seawater composition correction factors
 
 ```R
 library('kgen')
 
+# Calculate a single K
+calc_K(k, temp_c, sal, p_bar, magnesium, calcium, sulphate, fluorine, method)
+
+# Calculate multiple Ks
 calc_Ks(ks, temp_c, sal, p_bar, magnesium, calcium, sulphate, fluorine, method)
 
+# Pressure correction
 calc_pressure_correction(k, temp_c, p_bar)
+
+# Seawater correction
+calc_seawater_correction(k, sal, temp_c, magnesium, calcium, method)
 ```
 
 ## Arguments
 
-- **ks**: Character vector of coefficients, i.e., K<sub>0</sub>, K<sub>1</sub>, K<sub>2</sub>, K<sub>W</sub>, K<sub>B</sub>, K<sub>S</sub>, K<sub>spA</sub>, K<sub>spC</sub>, K<sub>P1</sub>, K<sub>P2</sub>, K<sub>P3</sub>, K<sub>Si</sub>, and K<sub>F</sub> if `NULL` all coefficients will be calculated.
+- **k**: Single K name to calculate, e.g., `"K0"`, `"K1"`.
+
+- **ks**: Character vector of coefficients, i.e., K<sub>0</sub>, K<sub>1</sub>, K<sub>2</sub>, K<sub>W</sub>, K<sub>B</sub>, K<sub>S</sub>, K<sub>spA</sub>, K<sub>spC</sub>, K<sub>P1</sub>, K<sub>P2</sub>, K<sub>P3</sub>, K<sub>Si</sub>, and K<sub>F</sub>. If `NULL` all coefficients will be calculated.
 
 - **temp_c**: Temperature in degree Celsius
 
@@ -44,20 +59,36 @@ calc_pressure_correction(k, temp_c, p_bar)
 
 - **p_bar**: Pressure in bar
 
-- **magnesium**: Magnesium concentration in mol kg<sup>-1</sup> 
+- **magnesium**: Magnesium concentration in mol kg<sup>-1</sup>
 
-- **calcium**: Calcium concentration in mol kg<sup>-1</sup> 
+- **calcium**: Calcium concentration in mol kg<sup>-1</sup>
 
 - **sulphate**: Sulphate concentration in mol/kgsw. Calculated from salinity if not given.
-- 
+
 - **fluorine**: Fluorine concentration in mol/kgsw. Calculated from salinity if not given.
 
-- **method**: Options: `R_Polynomial`, `MyAMI_Polynomial` , `MyAMI` (defaults to "MyAMI"). If set to `MyAMI`, Kgen will calculate Mg and Ca correction factors directly using `pymyami`. If set to `MyAMI_Polynomial` Kgen will approximate the correction factors using a polynomial approximation in `pymyami`. If set to `R_Polynomial` Kgen will approximate the correction factors using a built in polynomial approximation function. 
+- **method**: Options: `R_Polynomial`, `MyAMI_Polynomial`, `MyAMI` (defaults to `"R_Polynomial"`). If set to `MyAMI`, Kgen will calculate Mg and Ca correction factors directly using `pymyami`. If set to `MyAMI_Polynomial`, Kgen will approximate the correction factors using a polynomial approximation in `pymyami`. If set to `R_Polynomial`, Kgen will approximate the correction factors using a built-in polynomial approximation function.
 
-The inputs to **temp_c**, **p_bar**, **sal**, **magnesium**, **calcium**, **sulphate**, and **fluorine** may be single numbers or numeric vectors, but where they are vectors, the lengt of the vectors must be the same. If any value is not specified, it defaults back to 'standard' conditions of temp_c = 25 °C, sal = 35, and p_bar = 0 bar, with Mg and Ca at modern ocean concentrations (0.0528171 and 0.0102821 mol kg<sup>-1</sup>).
+The inputs to **temp_c**, **p_bar**, **sal**, **magnesium**, **calcium**, **sulphate**, and **fluorine** may be single numbers or numeric vectors, but where they are vectors, the length of the vectors must be the same. If any value is not specified, it defaults back to 'standard' conditions of temp_c = 25 °C, sal = 35, and p_bar = 0 bar, with Mg and Ca at modern ocean concentrations (0.0528171 and 0.0102821 mol kg<sup>-1</sup>).
+
+## Parallel Execution
+
+`calc_Ks()` uses the [future](https://future.futureverse.org/) framework for parallel computation. To enable parallel execution, set a `future::plan()` before calling `calc_Ks()`:
+
+```R
+library('kgen')
+
+# Enable parallel execution
+future::plan(future::multisession, workers = parallel::detectCores() - 1)
+
+# Calculate Ks in parallel
+result <- calc_Ks(temp_c = 25, sal = 35)
+
+# Reset to sequential
+future::plan(future::sequential)
+```
 
 ## Details
-For ease of use, Kgen will automatically install an `r-Miniconda` version in an isolated namespace location, required to run `pymyami` in R upon the first time `calc_Ks()`is called. This installation requires minimum disk space (~400 MB) and will not interfere with other Python versions on the operating system. However, if you prefer to install r-Miniconda to a specific path on your system (not recommended), install r-Miniconda manually using [reticulate](https://rstudio.github.io/reticulate/) before starting Kgen. When updated to a newer package version, Kgen ay ask the user to also perform a version update of pymyami. This is done to ensure that the version of pymyami remains constant between Kgen in R, Python, and Matlab.
 
 Kgen installation and operation example:
 
@@ -68,19 +99,13 @@ Kgen installation and operation example:
 # Load library
 > library('kgen')
 
-# Test coefficient calculation using default values
-> calc_Ks('K0')
-
-[1] "Kgen requires r-Miniconda, which appears to not exist on your system."
-Would you like to install it now? (Yes/no/abbrechen) 
-
-# Confirm installation
-> yes
-
-> calc_Ks('K0')
+# Calculate a single K with default values
+> calc_K('K0')
 [1] 0.02839188
+
+# Calculate all Ks
+> calc_Ks(temp_c = 25, sal = 35)
 ```
 
 ## See also
-Refer to [pyMyAMI on PyPi](https://pypi.org/project/pymyami/) to learn how Mg and Ca concentration factors are calculated.  Refer to [Reticulate](https://rstudio.github.io/reticulate/index.html) to learn more about how the Python integration in Kgen for R works.
-
+Refer to [pyMyAMI on PyPi](https://pypi.org/project/pymyami/) to learn how Mg and Ca concentration factors are calculated. Refer to [Reticulate](https://rstudio.github.io/reticulate/index.html) to learn more about how the Python integration in Kgen for R works.


### PR DESCRIPTION
## Summary
- Document all 4 exported functions (`calc_K`, `calc_Ks`, `calc_pressure_correction`, `calc_seawater_correction`)
- Fix default method: `R_Polynomial`, not `MyAMI`
- Remove outdated miniconda installation flow (now uses `reticulate::py_require`)
- Add parallel execution section documenting `future.apply` usage
- Fix typos and formatting issues

## Related
This update corresponds to the R code changes in the `fix/pr103-review-fixes` branch ([PR #104](https://github.com/PalaeoCarbonateChemistry/Kgen/pull/104)).

## Test plan
- [ ] Verify GitHub Pages renders correctly after merge
- [ ] Confirm all documented function signatures match the R package exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)