### PR TITLE
fix(r): limit BLAS/OpenMP threads in tests for CRAN

### DIFF
--- a/r/tests/testthat/setup.R
+++ b/r/tests/testthat/setup.R
@@ -1,8 +1,17 @@
-# Force sequential execution during tests to avoid CRAN NOTE
-# ("CPU time N times elapsed time" from parallel workers)
+# Force single-threaded execution during tests to avoid CRAN NOTE
+# ("CPU time N times elapsed time")
 if (requireNamespace("future", quietly = TRUE)) {
   future::plan(future::sequential)
 }
+
+# Limit BLAS/OpenMP threads used by NumPy/scipy via reticulate
+Sys.setenv(
+  OMP_NUM_THREADS = 1,
+  OPENBLAS_NUM_THREADS = 1,
+  MKL_NUM_THREADS = 1,
+  VECLIB_MAXIMUM_THREADS = 1,
+  NUMEXPR_NUM_THREADS = 1
+)
 
 skip_if_no_pymyami <- function() {
   have_pymyami <- reticulate::py_module_available("pymyami")


### PR DESCRIPTION
## Summary

Fixes the CRAN NOTE "CPU time 3.1 times elapsed time" that persisted after adding `future::plan(sequential)`.

The root cause is that pymyami tests call NumPy/scipy through reticulate, which uses multi-threaded BLAS internally. Setting `future::plan(sequential)` only controls R-level parallelism, not the underlying BLAS threads.

### Fix
Set thread-limiting env vars in `tests/testthat/setup.R`:
- `OMP_NUM_THREADS=1`
- `OPENBLAS_NUM_THREADS=1`
- `MKL_NUM_THREADS=1`
- `VECLIB_MAXIMUM_THREADS=1`
- `NUMEXPR_NUM_THREADS=1`

### Test results (with pymyami, all 4 tests running)
- CPU/elapsed ratio: **0.96x** (was 3.1x)
- All 4 tests pass including pymyami methods

## Test plan
- [x] Full test suite with pymyami: ratio 0.96x
- [x] All tests pass (4 pass, 0 skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)